### PR TITLE
Make clearer that set of validation RRsets can be in any order.

### DIFF
--- a/draft-ietf-tls-dnssec-chain-extension-04.xml
+++ b/draft-ietf-tls-dnssec-chain-extension-04.xml
@@ -384,11 +384,12 @@
       </t>
 
       <t>
-	The subsequent RRsets MUST contain the full sequence
+	The subsequent RRsets MUST contain the full set
 	of DNS records needed to authenticate the TLSA record set from the
-	server's trust anchor. Typically this means a sequence of DNSKEY
+	server's trust anchor. Typically this means a set of DNSKEY
 	and DS RRsets that cover all zones from the target zone containing
-	the TLSA record set to the trust anchor zone.
+	the TLSA record set to the trust anchor zone. The TLS client should
+	be prepared to receive this set of RRsets in any order.
       </t>
 
       <t>


### PR DESCRIPTION
Small tweak to text to make clearer that validation RRsets can be in any order.
