### PR TITLE
Eric Rescorla's first DISCUSS point

### DIFF
--- a/draft-ietf-tls-dnssec-chain-extension-07.xml
+++ b/draft-ietf-tls-dnssec-chain-extension-07.xml
@@ -315,9 +315,7 @@
     This sequence of native DNS wire format records enables easier
     generation of the data structure on the server and easier 
     verification of the data on client by means of existing DNS library
-    functions. However this document describes the data structure
-    in sufficient detail that implementers if they desire can write
-    their own code to do this.
+    functions.
       </t>
 
       <t>
@@ -337,8 +335,17 @@
       </figure>
 
       <t>
+    The resource records that make up a RRset all have the same owner,
+    type and class, but different RDATA as specified
+    <xref="RFC2181">RFC 2181</xref>, Section 5.
+
     Each RRset in the sequence is followed by its associated
-    RRsig record set.
+    RRsig record set.  This RRset has the same owner and class as the
+    preceding RRset, but has type RRSIG.  The Type Covered 
+    field in the RDATA of the RRsigs identifies the type of the
+    preceding RRset as described in
+    <xref target="RFC4034">RFC 4034</xref>, Section 3.
+
     The RRsig record wire format is described in
     <xref target="RFC4034">RFC 4034</xref>, Section 3.1. The 
     signature portion of the RDATA, as described in the same


### PR DESCRIPTION
Remove statement that the document describes the data structure in sufficient detail for implementers and describe more clearly how individual RRsets and the successive RRSig record set are identified by referencing the relevant sections in RFC's; and remove the in response to Eric Rescorla's DISCUSS point:

	IMPORTANT: I'm not sure that this is actually sufficient to allow an
	independent implementation without referring to the other documents. I
	mean, I think I pretty clearly can't validate this chain from the
	above. Similarly, although I think this is enough to break apart the
	RRSETs into RRs, it doesn't tell me how to separate the RRSETs from
	each other. I think you need to either make this a lot more complete
	or alternately stop saying it's sufficient.